### PR TITLE
Add test for future year error in get_urls

### DIFF
--- a/tests/testthat/test-pull.R
+++ b/tests/testthat/test-pull.R
@@ -22,3 +22,8 @@ test_that("get urls works", {
   expect_equal(get_urls(year), urls)
 })
 
+test_that("get urls requires past year", {
+  next_year <- as.integer(format(Sys.Date(), "%Y")) + 1
+  expect_error(get_urls(next_year), "Year must be in the past")
+})
+


### PR DESCRIPTION
## Summary
- add a regression test for get_urls expecting past year

## Testing
- `Rscript -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684171a145908326a8575ef26aa7db87